### PR TITLE
Pseudonym clarification

### DIFF
--- a/SBR.md
+++ b/SBR.md
@@ -475,7 +475,7 @@ Personal Names SHALL be a meaningful representation of the Subject’s name as v
 
 ### 3.1.3 Anonymity or pseudonymity of subscribers
 
-The purpose of the Pseudonym attribute is to provide a unique identifier linked to an Individual in a pseudonymized manner when certain privacy conditions are required. For example, a Pseudonym may be used if a government agency requires officials to sign certain decisions via S/MIME so those decisions trace back to individuals, but emphasize the importance of the role over Individual identity in the Certificate. The CA SHALL disclose in its CP and/or CPS if it allows the use of Pseudonyms.
+The purpose of a Pseudonym is to provide a unique identifier linked to an Individual in a pseudonymized manner when certain privacy conditions are required. For example, a Pseudonym may be used if a government agency requires officials to sign certain decisions via S/MIME so those decisions trace back to individuals, but emphasize the importance of the role over Individual identity in the Certificate. The CA SHALL disclose in its CP and/or CPS if it allows the use of Pseudonyms.
 
 For `Sponsor-validated` certificates, the CA MAY use a `subject:pseudonym` attribute in the Certificate if the associated Subject has been verified according to [Section 3.2.4](#324-authentication-of-individual-identity). If present, the `subject:pseudonym` attribute SHALL be:
 

--- a/SBR.md
+++ b/SBR.md
@@ -2062,6 +2062,8 @@ If present, the Personal Name SHALL contain a name of the Subject. The Personal 
 
 If present, the Mailbox Address SHALL contain a `rfc822Name` or `otherName` value of type `id-on-SmtpUTF8Mailbox` from `extensions:subjectAltName`.
 
+If present, the Pseudonym SHALL contain the subject:pseudonym if that subject attribute is also present.
+
 **Note**: Like all other Certificate attributes, `subject:commonName` and `subject:emailAddress` SHALL comply with the attribute upper bounds defined in [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280).
 
 Additional specifications for naming are provided in [Section 3.1](#31-naming).


### PR DESCRIPTION
So, this PR attempts to address some issues I commented about on #6 but I figured instead of just complaining I might as well try to fix them myself!

The main thing I'd like to address is adding clarity around when the subject:commonName contains a Pseudonym (big 'P') and how that commonName would relate to the subject:pseudonym attribute.

My assumption is that the previous change was made because the original version of the table required a subject:pseudonym attribute to be included in order for the subject:commonName to include a Pseudonym.  However, I think the text currently allows one to have two different Pseudonyms in a certificate so I've tried to prevent this with one of the changes in this PR.

The other point is a minor wording change where subject:pseudonym has been replaced with Pseudonym so the text currently says "the Pseudonym attribute" which conflates the attribute and the defined (big 'P') Pseudonym.