### PR TITLE
Update build-guidelines-action to version 2.2.1 (#299)

### DIFF
--- a/.github/workflows/build-draft-docs.yml
+++ b/.github/workflows/build-draft-docs.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha || github.event.push.before }}
           path: old/
-      - uses: cabforum/build-guidelines-action@v2.1.2
+      - uses: docker://ghcr.io/cabforum/build-guidelines-action:2.2.1
         id: build_doc
         with:
           markdown_file: ${{ matrix.document }}


### PR DESCRIPTION
* Update build-guidelines-action to version 2.2.1

* Update action to use Docker image for build guidelines